### PR TITLE
Fixes required version of illuminate components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/database": "^5.6",
-        "illuminate/events": "^5.6",
-        "illuminate/support": "^5.6"
+        "illuminate/database": "5.6.*",
+        "illuminate/events": "5.6.*",
+        "illuminate/support": "5.6.*"
     },
     "require-dev": {
         "orchestra/testbench": "^3.6",


### PR DESCRIPTION
Laravel components doesn’t follow Semantic Versioning.

Good article about that: [https://medium.com/@vinkla/laravel-packages-and-semantic-versioning-f62dc5accee5](https://medium.com/@vinkla/laravel-packages-and-semantic-versioning-f62dc5accee5)